### PR TITLE
Example: Use edge function for PowerSync authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # PowerSync + Supabase Flutter Demo: Todo List App
+
 ![docs-supabase-integration](https://github.com/journeyapps/powersync-supabase-flutter-demo/assets/277659/291fa2eb-abe6-4567-8d4b-c88e0ee850cf)
 
 Demo app demonstrating use of the PowerSync SDK for Flutter together with Supabase. For a step-by-step guide, see [here](https://docs.powersync.co/integration-guides/supabase).
+
+> [!NOTE]
+> This branch differs from the main one by using a Supabase Edge Function for authentication.
+> An example implementation of this function is in the [powersync-jwks-example](https://github.com/journeyapps/powersync-jwks-example/) repo.
 
 # Running the app
 

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -2,6 +2,4 @@ class AppConfig {
   static const String supabaseUrl = 'https://jrimaqxlgrpjipgssldo.supabase.co';
   static const String supabaseAnonKey =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpyaW1hcXhsZ3JwamlwZ3NzbGRvIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTE1ODY5MTAsImV4cCI6MjAwNzE2MjkxMH0.K-Qb-YFz0oVpLshUEezGU-Do-sX08zKqBzVccDoZp_Y';
-  static const String powersyncUrl =
-      'https://64d392172a3c226cddbd5070.powersync.journeyapps.com';
 }


### PR DESCRIPTION
**DO NOT MERGE**

This is an alternative version of the connector that uses a Supabase edge function for PowerSync authentication, instead of re-using the Supabase JWT.

Edge function example implementations are here: https://github.com/journeyapps/powersync-jwks-example/
